### PR TITLE
Removed route to test automation

### DIFF
--- a/.github/workflows/digital-ocean-deploy.yml
+++ b/.github/workflows/digital-ocean-deploy.yml
@@ -18,22 +18,18 @@ jobs:
      - name: Update deployment file
        run: ./update-version.sh $GITHUB_SHA
 
-     - name: Check Deployment file
-       run: echo $GITHUB_WORKSPACE/kube/afterparty-deployment.yaml
-
      - name: install doctl
        uses: digitalocean/action-doctl@v2
        with:
          token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
        
-     - name: Build container image
+     - name: Build container image With SHA
        uses: docker/build-push-action@v1
        with:
          username: dokun1
          password: ${{ secrets.DOCKER_PASSWORD }}
          repository: dokun1/afterparty-server-testing
          tag_with_sha: true
-         tags: latest
          dockerfile: ./web.Dockerfile
          build_args: env=docker
 

--- a/Sources/App/routes.swift
+++ b/Sources/App/routes.swift
@@ -13,10 +13,6 @@ public func routes(_ router: Router) throws {
     return "Hello, world!"
   }
  
-  router.get("versioning") { req in
-    return "This is the latest version!"
-  }
-  
   router.get("hello", String.parameter) { req -> String in
     let name = try req.parameters.next(String.self)
     return "Hello \(name)"

--- a/update-version.sh
+++ b/update-version.sh
@@ -4,7 +4,7 @@ tagName=${1}
 shortenedTag="$(echo $tagName | head -c 7)"
 shaTag="sha-${shortenedTag}"
 
-echo $shaTag
+echo "Building Image Version: $shaTag"
 
 rm -f ./kube/afterparty-deployment.yaml
 


### PR DESCRIPTION
Removed the `/versioning` route as a means to test if merging to `main` will automatically deploy the latest version to prod.